### PR TITLE
[q-implant] Add validation of output.circle of op-level-test

### DIFF
--- a/compiler/q-implant-op-level-test/CMakeLists.txt
+++ b/compiler/q-implant-op-level-test/CMakeLists.txt
@@ -1,0 +1,22 @@
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
+unset(Q_IMPLANT_TESTS)
+
+macro(addeval NAME)
+  list(APPEND Q_IMPLANT_TESTS ${NAME})
+endmacro(addeval)
+
+include("test.lst")
+
+get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
+
+add_test(NAME q_implant_op_level_test
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/q-implant-op-level-test.sh"
+          "${CMAKE_CURRENT_BINARY_DIR}"
+          "${ARTIFACTS_BIN_PATH}"
+          "${NNCC_OVERLAY_DIR}/venv_2_12_1"
+          "$<TARGET_FILE:q-implant>"
+          ${Q_IMPLANT_TESTS}
+)

--- a/compiler/q-implant-op-level-test/CMakeLists.txt
+++ b/compiler/q-implant-op-level-test/CMakeLists.txt
@@ -18,5 +18,6 @@ add_test(NAME q_implant_op_level_test
           "${ARTIFACTS_BIN_PATH}"
           "${NNCC_OVERLAY_DIR}/venv_2_12_1"
           "$<TARGET_FILE:q-implant>"
+          "$<TARGET_FILE:circle-tensordump>"
           ${Q_IMPLANT_TESTS}
 )

--- a/compiler/q-implant-op-level-test/README.md
+++ b/compiler/q-implant-op-level-test/README.md
@@ -1,0 +1,20 @@
+# q-implant-op-level-test
+
+`q-implant-op-level-test` validates that q-implant supports common used operators.
+
+The test proceeds as follows
+
+Step 1: Generate tflite files and circle files from TFLite recipes (listsed in test.lst).
+```
+"TFLite recipe" -> tflchef -> "tflite file" -> tflite2circle -> "circle file"
+```
+
+Step 2: Generate qparam file(.json) and numpy array(.npy) for the operator python file.
+```
+operator file -> qparam file, numpy array
+```
+
+Step 3: Generate output.circle to use q-implant
+```
+"circle file" + "qparam.json" -> q-implant -> "quant circle file"
+```

--- a/compiler/q-implant-op-level-test/README.md
+++ b/compiler/q-implant-op-level-test/README.md
@@ -18,3 +18,10 @@ Step 3: Generate output.circle to use q-implant
 ```
 "circle file" + "qparam.json" -> q-implant -> "quant circle file"
 ```
+
+Step 4: Dump output.circle to output.h5.
+```
+"output.circle" -> sircle-tensordump -> "output.h5"
+```
+
+Step 5: And compare tensor values of h5 file with numpy arrays due to validate q-implant.

--- a/compiler/q-implant-op-level-test/requires.cmake
+++ b/compiler/q-implant-op-level-test/requires.cmake
@@ -1,0 +1,2 @@
+require("common-artifacts")
+require("q-implant")


### PR DESCRIPTION
This will add h5 dumping and compare step to validate tensor value of output.circle.

ONE-DCO-1.0-Signed-off-by: Jaehong Ju <wnwoghd22@gmail.com>